### PR TITLE
Fix to be able to fight again without reopening and creation of TURN_TIMEOUT_SECS

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,24 @@
-/bin
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
 /bin/
-Battlefield jar files.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bin
 /bin/
+Battlefield jar files.txt

--- a/Battlefield jar files.txt
+++ b/Battlefield jar files.txt
@@ -1,4 +1,4 @@
-file:/C:/Users/Gabriel/Documents/AlanWarrior.jar
-Warrior.MyWarriorManager
-file:/C:/Users/Gabriel/Documents/FluxCap3.jar
-CondensadorDeFlujo
+file:/C:/Users/lchao/Desktop/Klingon.jar
+ia.battle.bot.Trainer
+file:/C:/Users/lchao/Desktop/ElEntrenador.jar
+ElEntrenador

--- a/Battlefield jar files.txt
+++ b/Battlefield jar files.txt
@@ -1,4 +1,0 @@
-file:/C:/Users/lchao/Desktop/Klingon.jar
-ia.battle.bot.Trainer
-file:/C:/Users/lchao/Desktop/ElEntrenador.jar
-ElEntrenador

--- a/src/ia/battle/core/BattleField.java
+++ b/src/ia/battle/core/BattleField.java
@@ -47,6 +47,8 @@ import ia.exceptions.RuleException;
 //TODO: Cambio de warriors
 
 public class BattleField {
+	
+	private static final int TURN_TIMEOUT_SECS = Integer.MAX_VALUE;
 
 	private ArrayList<GeneralListener> listeners;
 	private ArrayList<TimerListener> timerListeners;
@@ -380,7 +382,7 @@ public class BattleField {
 					Future<Action> future = executor.submit(new PlayTurnExecutor(currentWarriorWrapper, tick, i));
 
 					try {
-						currentWarriorAction = future.get(2, TimeUnit.SECONDS);						
+						currentWarriorAction = future.get(TURN_TIMEOUT_SECS, TimeUnit.SECONDS);						
 					} catch (InterruptedException | ExecutionException | TimeoutException e) {
 						future.cancel(true);
 						System.err.println(e);

--- a/src/ia/battle/core/BattleField.java
+++ b/src/ia/battle/core/BattleField.java
@@ -48,7 +48,7 @@ import ia.exceptions.RuleException;
 
 public class BattleField {
 	
-	private static final int TURN_TIMEOUT_SECS = Integer.MAX_VALUE;
+	private static final int TURN_TIMEOUT_SECS = 2;
 
 	private ArrayList<GeneralListener> listeners;
 	private ArrayList<TimerListener> timerListeners;
@@ -80,6 +80,10 @@ public class BattleField {
 	}
 
 	public static BattleField getInstance() {
+		return instance;
+	}
+	public static BattleField getNewInstance() {
+		instance = new BattleField();
 		return instance;
 	}
 

--- a/src/ia/battle/gui/BattleFieldSetup.java
+++ b/src/ia/battle/gui/BattleFieldSetup.java
@@ -207,6 +207,8 @@ public class BattleFieldSetup extends JFrame {
 
 	protected void figthClicked() {
 
+		BattleField.getNewInstance();
+		
 		saveJarSelection();
 
 		WarriorLoader warriorLoader = new WarriorLoader();


### PR DESCRIPTION
- Added BattleField.getNewInstance():
    Creates new instance of BattleField to cleanup after fight
    On fightClicked first calls BattleField.getNewInstance()
- Created BattleField.TURN_TIMEOUT_SECS static var to change timeout for debugging